### PR TITLE
Remove the async attribute for web components polyfill

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -66,7 +66,6 @@
 
         if (!webComponentsSupported) {
           var script = document.createElement('script');
-          script.async = true;
           script.src = '/bower_components/webcomponentsjs/webcomponents-lite.min.js';
           document.body.appendChild(script);
         }


### PR DESCRIPTION
This isn't needed because if web components aren't supported, they're not going to see anything until it's polyfilled and browsers that support web components won't run this anyway.
